### PR TITLE
Fix profile route

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,12 +19,6 @@ const port = process.env.PORT || 5000;
 app.listen(port, () => console.log("Backend started on port " + port))
 
 
-//sets routes for static build in production
-if (process.env.NODE_ENV === "production") {
-  app.use(express.static("client/build"))
-
-  app.get("/", (req, res) => res.sendFile(path.resolve(__dirname, 'client', "build", "index.html")))
-}
 
 
 //User Requests
@@ -46,3 +40,10 @@ app.use("/item/move", require("./routes/item/move"))
 
 //Service Requests
 app.use("/services/weather", require("./routes/services/weather"))
+
+//sets routes for static build in production
+if (process.env.NODE_ENV === "production") {
+  app.use(express.static("client/build"))
+
+  app.get("*", (req, res) => res.sendFile(path.resolve(__dirname, 'client', "build", "index.html")))
+}

--- a/app.js
+++ b/app.js
@@ -24,7 +24,6 @@ if (process.env.NODE_ENV === "production") {
   app.use(express.static("client/build"))
 
   app.get("/", (req, res) => res.sendFile(path.resolve(__dirname, 'client', "build", "index.html")))
-  app.get("/today", (req, res) => res.sendFile(path.resolve(__dirname, 'client', "build", "index.html")))
 }
 
 


### PR DESCRIPTION
Changes the server file's route handlers for a production build.  

Instead of declaring routes, switch the route to a wildcard and move it to the bottom of all routes.

If it's at the top of the file it will hit the wildcard route for all API requests, so it will stay at the bottom as the last route.  This should future proof if any new routes are added.