### PR TITLE
Serve static assets as compressed files

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,8 +44,8 @@ app.use("/services/weather", require("./routes/services/weather"))
 
 //sets routes for static build in production
 if (process.env.NODE_ENV === "production") {
-  app.use("*", expressStaticGzip(path.resolve(__dirname, 'client', "build")))
+  app.use(expressStaticGzip(path.resolve(__dirname, 'client', "build")))
   // app.use(express.static("client/build"))
 
-  // app.get("*", (req, res) => res.sendFile(path.resolve(__dirname, 'client', "build", "index.html")))
+  app.get("*", (req, res) => res.sendFile(path.resolve(__dirname, 'client', "build", "index.html")))
 }

--- a/app.js
+++ b/app.js
@@ -44,8 +44,8 @@ app.use("/services/weather", require("./routes/services/weather"))
 
 //sets routes for static build in production
 if (process.env.NODE_ENV === "production") {
-  app.use("*", expressStaticGzip("client/build/index.html"));
+  app.use("*", expressStaticGzip(path.resolve(__dirname, 'client', "build")))
   // app.use(express.static("client/build"))
 
-  app.get("*", (req, res) => res.sendFile(path.resolve(__dirname, 'client', "build", "index.html")))
+  // app.get("*", (req, res) => res.sendFile(path.resolve(__dirname, 'client', "build", "index.html")))
 }

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 const express = require("express");
 const secure = require("ssl-express-www")
+const expressStaticGzip = require("express-static-gzip");
 const path = require("path")
 const connectDB = require("./db/db")
 
@@ -43,7 +44,8 @@ app.use("/services/weather", require("./routes/services/weather"))
 
 //sets routes for static build in production
 if (process.env.NODE_ENV === "production") {
-  app.use(express.static("client/build"))
+  app.use("*", expressStaticGzip("client/build"));
+  // app.use(express.static("client/build"))
 
-  app.get("*", (req, res) => res.sendFile(path.resolve(__dirname, 'client', "build", "index.html")))
+  // app.get("*", (req, res) => res.sendFile(path.resolve(__dirname, 'client', "build", "index.html")))
 }

--- a/app.js
+++ b/app.js
@@ -45,7 +45,6 @@ app.use("/services/weather", require("./routes/services/weather"))
 //sets routes for static build in production
 if (process.env.NODE_ENV === "production") {
   app.use(expressStaticGzip(path.resolve(__dirname, 'client', "build")))
-  // app.use(express.static("client/build"))
 
   app.get("*", (req, res) => res.sendFile(path.resolve(__dirname, 'client', "build", "index.html")))
 }

--- a/app.js
+++ b/app.js
@@ -44,8 +44,8 @@ app.use("/services/weather", require("./routes/services/weather"))
 
 //sets routes for static build in production
 if (process.env.NODE_ENV === "production") {
-  app.use("*", expressStaticGzip("client/build"));
+  app.use(expressStaticGzip("client/build"));
   // app.use(express.static("client/build"))
 
-  // app.get("*", (req, res) => res.sendFile(path.resolve(__dirname, 'client', "build", "index.html")))
+  app.get("*", (req, res) => res.sendFile(path.resolve(__dirname, 'client', "build", "index.html")))
 }

--- a/app.js
+++ b/app.js
@@ -44,7 +44,7 @@ app.use("/services/weather", require("./routes/services/weather"))
 
 //sets routes for static build in production
 if (process.env.NODE_ENV === "production") {
-  app.use(expressStaticGzip("client/build"));
+  app.use("*", expressStaticGzip("client/build/index.html"));
   // app.use(express.static("client/build"))
 
   app.get("*", (req, res) => res.sendFile(path.resolve(__dirname, 'client', "build", "index.html")))

--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts build && compress-cra -d /client/build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,8 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build && compress-cra -d /client/build",
+    "build": "react-scripts build",
+    "postbuild": "gzip build/static/js/*.js && gzip build/static/css/*.css",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build && compress-cra",
+    "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts build && compress-cra",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/client/package.json
+++ b/client/package.json
@@ -22,8 +22,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
-    "postbuild": "gzip build/static/js/*.js && gzip build/static/css/*.css",
+    "build": "react-scripts build && gzip build/static/js/*.js && gzip build/static/css/*.css",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -705,6 +705,14 @@
         "vary": "~1.1.2"
       }
     },
+    "express-static-gzip": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/express-static-gzip/-/express-static-gzip-2.1.1.tgz",
+      "integrity": "sha512-J+xSzdr5lj1cIuZey0ac6nUv22VE7GrdwTERqE8DsrqSXLm1zjeYWTVbK37t8exGwobxBXeWU2bM7eSMjBR4YA==",
+      "requires": {
+        "serve-static": "^1.14.1"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,12 @@
         "picomatch": "^2.0.4"
       }
     },
+    "app-root-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.0.0.tgz",
+      "integrity": "sha512-qMcx+Gy2UZynHjOHOIXPNvpf+9cjvk3cWrBBK7zg4gH9+clobJRb9NGzcT7mQTcV/6Gm/1WelUtqxVXnNlrwcw==",
+      "dev": true
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -372,6 +378,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "compress-create-react-app": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/compress-create-react-app/-/compress-create-react-app-1.1.3.tgz",
+      "integrity": "sha512-3HCWi9q7TqxBvklmJY/Pm96Fs8wqEXxduW3LGlK0PUYuezZwKkjB454GjyGhjKmxKpl91Q9b2+ZjXeKdNOIhlA==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "^3.0.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ssl-express-www": "^3.0.7"
   },
   "devDependencies": {
+    "compress-create-react-app": "^1.1.3",
     "concurrently": "^5.3.0",
     "nodemon": "^2.0.6"
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "bson-objectid": "^2.0.1",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "express-static-gzip": "^2.1.1",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.10.11",
     "react-datepicker": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "ssl-express-www": "^3.0.7"
   },
   "devDependencies": {
-    "compress-create-react-app": "^1.1.3",
     "concurrently": "^5.3.0",
     "nodemon": "^2.0.6"
   }


### PR DESCRIPTION
Installed the `compress-create-react-app` npm package to compress the static assets during the build phase.

Currently not configured correctly as I get an error output trying to run the build command as specified in the documentation.

After some configuration errors, I abandoned the `compress-cra` command and explicitly added a `gzip` command to my build script to compress all `.css` and `.js` files in the `build/static` folder.

I added the `express-static-gzip` package to serve up the compressed files to the client.