### PR TITLE
Improve page layouts

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -2,27 +2,29 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <meta name="description" content="Day planner app" />
+    <meta property="og:url" content="https://leather-journal.herokuapp.com" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Leather Day Planner" />
     <meta
-      name="description"
-      content="Day planner app"
+      property="og:description"
+      content="A daily todo list application styled to look like a classic leather journal.  Select any date and start planning."
     />
-    <meta property="og:url" content="https://leather-journal.herokuapp.com">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Leather Day Planner">
-    <meta property="og:description" content="A daily todo list application styled to look like a classic leather journal.  Select any date and start planning.">
-    <meta property="og:image" content="http://i.imgur.com/w1E3fLd.png">
-    <meta property="og:image:secure_url" content="https://i.imgur.com/w1E3fLd.png">
-    <meta property="og:type" content="image/png">
-    <meta property="og:image:width" content="400">
-    <meta property="og:image:height" content="400">
+    <meta property="og:image" content="http://i.imgur.com/w1E3fLd.png" />
+    <meta property="og:image:secure_url" content="https://i.imgur.com/w1E3fLd.png" />
+    <meta property="og:type" content="image/png" />
+    <meta property="og:image:width" content="400" />
+    <meta property="og:image:height" content="400" />
     <meta name="author" content="David Irvin" />
 
-    
-    <link href="/css/owfont-regular.css" rel="stylesheet" type="text/css">
-    <link rel="icon" href="/images/journal.webp">
-    <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@700&family=Libre+Baskerville:wght@400;700&display=swap" rel="stylesheet">
+    <link href="/css/owfont-regular.css" rel="stylesheet" type="text/css" />
+    <link rel="icon" href="/images/journal.webp" />
+    <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@700&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@700&family=Libre+Baskerville:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
 
     <title>Day Planner</title>
   </head>

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -244,7 +244,6 @@ li {
 .profile--wrapper input[type="text"],
 .password-reset input {
   display: block;
-  display: flex;
   font-family: var(--serif-font) !important;
   font-weight: 400 !important;
   font-size: 18px !important;
@@ -708,10 +707,7 @@ input[type="text"].new-item,
 
 .password-reset input[type="password"],
 .password-reset input[type="text"] {
-  margin-left: 1rem;
-  height: 34px;
-  margin-bottom: 1px;
-  padding-top: 6px;
+  text-indent: 1rem !important;
   font-family: var(--serif-font);
   font-size: 1rem;
   max-width: 200px;
@@ -844,8 +840,15 @@ button.button-appear-exit-done {
   display: flex;
   align-items: center;
   cursor: pointer;
-  padding: 0.125rem 0.25rem;
+  /* padding: 0.125rem 0.25rem; */
+  padding: 0;
   border-radius: 2px;
+}
+
+.change-city-button:focus {
+  outline: auto;
+  outline-offset: 2px;
+  outline-color: black;
 }
 
 .get-weather {
@@ -915,6 +918,8 @@ button.button-appear-exit-done {
 
 .weather-input__wrapper button:focus {
   background: inherit;
+  outline: auto;
+  outline-color: black;
 }
 
 /* OWFont override */
@@ -931,18 +936,20 @@ button.button-appear-exit-done {
 }
 
 .widget > *,
-.date-picker {
+.date-picker,
+.user-nav a {
   height: 24px;
   justify-content: flex-end;
   color: black;
 }
 
 /* .widget > *:focus, */
-.widget > *:focus-within,
+/* .widget > *:focus-within, */
 .user-nav a:focus {
   outline: auto;
   outline-offset: 2px;
   outline-color: black;
+  outline-style: auto;
 }
 
 .temp {
@@ -977,6 +984,12 @@ label.user-nav {
 
 .widget button.logout-button:hover {
   background-color: rgba(0, 0, 0, 0.04);
+}
+
+.widget button.logout-button:focus {
+  outline-offset: 2px;
+  outline-color: black;
+  outline: auto;
 }
 
 .planner-toggle__wrapper {
@@ -1226,7 +1239,6 @@ label.user-nav {
 
 .password-input .password-visibility {
   position: absolute;
-  right: 1rem;
   top: 50%;
   transform: translateY(-50%);
 }
@@ -1238,11 +1250,15 @@ label.user-nav {
   background: none;
   display: flex;
   cursor: pointer;
+  inset: 1px 0 1px auto;
+  height: calc(100% - 2px);
+  aspect-ratio: 1 / 1;
+  align-items: center;
+  justify-content: center;
 }
 
 .password-visibility:focus {
   outline: auto;
-  outline-offset: 2px;
 }
 
 .password-visibility svg {
@@ -1415,9 +1431,12 @@ label.user-nav {
     flex-direction: row-reverse;
     color: var(--faded);
     padding-right: 0;
+    gap: 6px;
   }
 
-  .widget > * {
+  .widget > *,
+  .date-picker,
+  .user-nav a {
     height: 37px;
     flex-basis: 25%;
   }
@@ -1483,10 +1502,6 @@ label.user-nav {
 
   .user-nav {
     justify-self: center;
-  }
-
-  .user-nav a {
-    height: auto;
   }
 
   .user-nav a * {
@@ -1618,10 +1633,11 @@ label.user-nav {
   .password-reset {
     position: relative;
     top: 32px;
+    top: var(--paper-line-height);
   }
 
   .password-reset input {
-    height: 32px !important;
+    height: calc(var(--paper-line-height) - 1px);
   }
 
   .password-reset input::placeholder {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -25,10 +25,16 @@ html {
 }
 
 body {
+  margin: 0;
+  background-color: var(--brown-color);
+}
+
+#root {
   background-color: var(--wood-color);
   background-image: var(--wood-texture);
   background-blend-mode: color-burn;
-  margin: 0;
+  height: 100svh;
+  display: flex;
 }
 
 a {
@@ -371,6 +377,7 @@ button.password--submit {
   background: none;
   border: none;
   cursor: pointer;
+  color: black;
   opacity: 0;
   padding: 0.125rem 0.25rem;
   display: flex;
@@ -438,8 +445,8 @@ li:where(:hover, :focus-within) .list-wrapper .expand-item {
 
 .notes-container .add-note--button {
   position: absolute;
-  right: 0.5rem;
-  top: 2.5rem;
+  /* right: 0.5rem;
+  top: 2.5rem; */
   height: 2.5rem;
   width: 2.5rem;
   background-color: #d4caa3;
@@ -481,6 +488,7 @@ li:where(:hover, :focus-within) .list-wrapper .expand-item {
   background: none;
   border: none;
   cursor: pointer;
+  color: black;
   opacity: 0;
   padding: 0.125rem 0.25rem;
   display: flex;
@@ -524,6 +532,10 @@ li:where(:hover, :focus-within) .list-wrapper .expand-item {
 .notes-list .eedit-note-form-action:focus {
   background-color: rgba(0, 0, 0, 0.1);
   color: unset;
+}
+
+.edit-note-form-action svg {
+  color: black;
 }
 
 .notes-list > form > .edit-note-form-action:first-of-type {
@@ -605,6 +617,7 @@ li:where(:hover, :focus-within) .list-wrapper .expand-item {
 .menu-action-button {
   padding: 0;
   background: transparent;
+  color: black;
   border: none;
   display: flex;
   cursor: pointer;
@@ -669,12 +682,12 @@ input:-webkit-autofill:active {
 input[type="text"].new-item,
 .password-reset input {
   width: 100%;
-  height: 29px;
+  line-height: calc(var(--paper-line-height) - 2px);
   font-size: 20px;
   max-width: 75%;
   background-color: transparent;
   font-family: var(--script-font);
-  text-indent: 4px;
+  text-indent: 30px;
   text-overflow: ellipsis;
   margin: 0;
   padding: 0;
@@ -709,6 +722,7 @@ input[type="text"]::placeholder,
   font-family: var(--script-font);
   font-size: 20px;
   color: grey;
+  line-height: calc(var(--paper-line-height) - 2px);
 }
 
 textarea {
@@ -719,14 +733,24 @@ textarea {
   background-color: transparent;
 }
 
+.list-inline-edit input[type="text"].new-item {
+  text-indent: 4px;
+}
+
 .list-item-form {
   display: flex;
   gap: 1rem;
+  align-items: center;
+  width: calc(100% - 2px);
 }
 
 .list-item-form button {
   background-color: #d4caa3;
   border: 1px solid var(--leather-color);
+  height: calc(var(--paper-line-height) - 2px);
+  min-height: initial;
+  width: initial;
+  min-width: calc(var(--paper-line-height) - 2px);
 }
 
 .list-item-form button:hover {
@@ -743,12 +767,14 @@ textarea {
   transform: scale(0) !important;
 }
 
-.button-appear-enter-active {
+.button-appear-enter-active,
+.button-appear-enter-done {
   transform: scale(1) !important;
   transition: transform 150ms cubic-bezier(0.44, 1.65, 0.69, 0.815) !important;
 }
 
-.button-appear-exit-active {
+.button-appear-exit-active,
+.button-appear-exit-done {
   transform: rotateZ(360deg) scale(0) !important;
   transition: transform 350ms ease !important;
 }
@@ -865,13 +891,15 @@ textarea {
 .date-picker {
   height: 24px;
   justify-content: flex-end;
+  color: black;
 }
 
-.widget > *:focus,
+/* .widget > *:focus, */
 .widget > *:focus-within,
 .user-nav a:focus {
+  outline: auto;
   outline-offset: 2px;
-  outline-color: currentColor;
+  outline-color: black;
 }
 
 .temp {
@@ -1181,6 +1209,13 @@ label.user-nav {
 /* Tablet size */
 
 @media (max-width: 850px) {
+  body,
+  html,
+  #root,
+  .position-div {
+    overscroll-behavior: none;
+  }
+
   .heading h1 {
     font-size: 2.3rem;
   }
@@ -1196,9 +1231,9 @@ label.user-nav {
   .position-div {
     display: block;
     width: 100%;
-    margin: auto;
-    height: 100vh;
-    max-height: 1150px;
+    margin: 0;
+    height: 100svh;
+    /* max-height: 1150px; */
   }
 
   .page {
@@ -1235,6 +1270,7 @@ label.user-nav {
     width: 400px;
     right: 5%;
     bottom: 10%;
+    position: fixed;
   }
 
   .center-div {
@@ -1273,6 +1309,10 @@ label.user-nav {
 
   .profile--wrapper > * {
     margin-bottom: 33px;
+  }
+
+  input[type="text"].new-item {
+    text-indent: 22px;
   }
 
   .profile--wrapper input[type="text"].new-item {
@@ -1332,6 +1372,11 @@ label.user-nav {
   .widget > * {
     height: 37px;
     flex-basis: 25%;
+  }
+
+  .widget > *,
+  .date-picker {
+    color: var(--faded);
   }
 
   .widget input,
@@ -1481,8 +1526,6 @@ label.user-nav {
   input[type="text"].new-item {
     max-width: none;
     font-size: 18px !important;
-    height: 25px;
-    text-indent: 0;
   }
 
   input[type="text"]::placeholder {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -57,6 +57,16 @@ li {
   list-style: none;
 }
 
+.list-marker {
+  position: absolute;
+  top: 6px;
+  left: -28px;
+}
+
+.list-marker.complete {
+  opacity: 0.6;
+}
+
 .position-div {
   width: fit-content;
   margin: 40px auto auto;
@@ -397,8 +407,9 @@ li:where(:hover, :focus-within) .list-wrapper .expand-item {
 .notes-border {
   position: absolute;
   width: calc(100% + 2rem);
-  top: calc(100% + 1px);
-  left: -2rem;
+  /* top: calc(100% + 1px);
+  left: -2rem; */
+  inset: calc(100% + 1px) 0 auto -2rem;
   z-index: 3;
   background: var(--leather-color) var(--leather-texture);
   padding: 0.4rem 0.5rem 0.5rem 0.4rem;
@@ -604,7 +615,6 @@ li:where(:hover, :focus-within) .list-wrapper .expand-item {
 }
 
 .menu-action-list {
-  background: var(--paper-color) var(--paper-texture);
   display: flex;
   align-items: center;
   gap: 2px;
@@ -623,6 +633,7 @@ li:where(:hover, :focus-within) .list-wrapper .expand-item {
   cursor: pointer;
   padding: 0.125rem 0.25rem;
   border-radius: 2px;
+  transition: background-color 75ms ease;
 }
 
 .menu svg {
@@ -630,7 +641,7 @@ li:where(:hover, :focus-within) .list-wrapper .expand-item {
 }
 
 .menu-action-button:hover {
-  background: #ccc38c var(--paper-texture);
+  background-color: rgba(0, 0, 0, 0.04);
   outline: none;
 }
 
@@ -682,7 +693,7 @@ input:-webkit-autofill:active {
 input[type="text"].new-item,
 .password-reset input {
   width: 100%;
-  line-height: calc(var(--paper-line-height) - 2px);
+  line-height: calc(var(--paper-line-height) - 1px);
   font-size: 20px;
   max-width: 75%;
   background-color: transparent;
@@ -722,7 +733,7 @@ input[type="text"]::placeholder,
   font-family: var(--script-font);
   font-size: 20px;
   color: grey;
-  line-height: calc(var(--paper-line-height) - 2px);
+  line-height: calc(var(--paper-line-height) - 1px);
 }
 
 textarea {
@@ -733,8 +744,27 @@ textarea {
   background-color: transparent;
 }
 
+.list-inline-edit {
+  line-height: normal;
+}
+
+.list-inline-edit::before {
+  content: "";
+  position: absolute;
+  z-index: 3;
+  inset: 0 0 0 -2rem;
+  border-radius: 0.5rem;
+  outline: 2px solid var(--brown-color);
+  background: none;
+}
+
 .list-inline-edit input[type="text"].new-item {
-  text-indent: 4px;
+  text-indent: 0px;
+  font-size: inherit !important;
+  /* line-height: inherit; */
+  letter-spacing: 1.5px;
+  word-spacing: 3px;
+  max-width: initial;
 }
 
 .list-item-form {
@@ -742,9 +772,10 @@ textarea {
   gap: 1rem;
   align-items: center;
   width: calc(100% - 2px);
+  z-index: 3;
 }
 
-.list-item-form button {
+.list-item-form button.new-item-submit {
   background-color: #d4caa3;
   border: 1px solid var(--leather-color);
   height: calc(var(--paper-line-height) - 2px);
@@ -754,7 +785,7 @@ textarea {
 }
 
 .list-item-form
-  button:not(
+  button.new-item-submit:not(
     .button-appear-exit,
     .button-appear-enter,
     .button-appear-exit-active,
@@ -764,7 +795,7 @@ textarea {
   transform: scale(0);
 }
 
-.list-item-form button:hover {
+.list-item-form button.new-item-submit:hover {
   background-color: var(--leather-color);
   color: #d4caa3;
   cursor: pointer;
@@ -1236,7 +1267,15 @@ label.user-nav {
   }
 
   ul.list {
-    padding-left: 22px;
+    padding-left: 25px;
+  }
+
+  .list-marker {
+    left: -26px;
+  }
+
+  .list-inline-edit::before {
+    inset: 0 0.125rem 0 -1.6rem;
   }
 
   .position-div {
@@ -1250,8 +1289,9 @@ label.user-nav {
   .page {
     width: 97%;
     margin: 2% auto;
-    padding: 10px 5px 2px 20px;
+    padding: 10px 5px 2px 15px;
     height: 96%;
+    overflow: visible;
   }
 
   .grid-div {
@@ -1338,8 +1378,8 @@ label.user-nav {
   :root {
     --faded: rgba(2, 2, 2, 0.664);
     --paper-line-height: 34px;
-    --paper-line: 33px;
-    --paper-font-size: 24px;
+    --paper-line: 1px 33px;
+    --paper-font-size: 20px;
   }
 
   html {
@@ -1490,14 +1530,11 @@ label.user-nav {
 
   .pattern {
     width: 100%;
-    background-image: var(--paper-texture),
-      repeating-linear-gradient(#fff4b0 1px var(--paper-line), blue var(--paper-line-height));
   }
 
   .content {
-    line-height: var(--paper-line);
-    font-size: 22px;
-    padding-top: var(--paper-line-height);
+    line-height: calc(var(--paper-line-height) - 1px);
+    word-spacing: initial;
   }
 
   .list li {
@@ -1506,6 +1543,14 @@ label.user-nav {
 
   li::marker {
     font-size: 1rem;
+  }
+
+  .list-marker {
+    left: -23px;
+  }
+
+  .list-inline-edit::before {
+    inset: 0 0.125rem 0 -1.45rem;
   }
 
   .menu-action-list {
@@ -1538,6 +1583,10 @@ label.user-nav {
 
   input[type="text"]::placeholder {
     font-size: 18px;
+  }
+
+  .list-wrapper .expand-item {
+    top: 2px;
   }
 
   .notes-container input {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -406,9 +406,6 @@ li:where(:hover, :focus-within) .list-wrapper .expand-item {
 
 .notes-border {
   position: absolute;
-  width: calc(100% + 2rem);
-  /* top: calc(100% + 1px);
-  left: -2rem; */
   inset: calc(100% + 1px) 0 auto -2rem;
   z-index: 3;
   background: var(--leather-color) var(--leather-texture);
@@ -440,6 +437,10 @@ li:where(:hover, :focus-within) .list-wrapper .expand-item {
   text-indent: 1rem;
   font-family: var(--script-font);
   font-size: 1.5rem;
+}
+
+.notes-container input:not(.edit-note) {
+  line-height: calc(var(--paper-line-height) - 1px);
 }
 
 .notes-container input[type="text"]:focus {
@@ -1307,7 +1308,6 @@ label.user-nav {
 
   .notes-border {
     left: -1.5rem;
-    width: calc(100% + 1.5rem);
   }
 
   .binder-rings,

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -753,6 +753,17 @@ textarea {
   min-width: calc(var(--paper-line-height) - 2px);
 }
 
+.list-item-form
+  button:not(
+    .button-appear-exit,
+    .button-appear-enter,
+    .button-appear-exit-active,
+    .button-appear-enter-active,
+    .button-appear-enter-done
+  ) {
+  transform: scale(0);
+}
+
 .list-item-form button:hover {
   background-color: var(--leather-color);
   color: #d4caa3;
@@ -763,20 +774,20 @@ textarea {
   font-size: 1.1rem;
 }
 
-.button-appear-enter {
-  transform: scale(0) !important;
+button.button-appear-enter {
+  transform: scale(0);
 }
 
-.button-appear-enter-active,
-.button-appear-enter-done {
-  transform: scale(1) !important;
-  transition: transform 150ms cubic-bezier(0.44, 1.65, 0.69, 0.815) !important;
+button.button-appear-enter-active,
+button.button-appear-enter-done {
+  transform: scale(1);
+  transition: transform 150ms cubic-bezier(0.44, 1.65, 0.69, 0.815);
 }
 
-.button-appear-exit-active,
-.button-appear-exit-done {
-  transform: rotateZ(360deg) scale(0) !important;
-  transition: transform 350ms ease !important;
+button.button-appear-exit-active.button-appear-exit,
+button.button-appear-exit-done {
+  transition: transform 350ms ease;
+  transform: rotateZ(360deg) scale(0);
 }
 
 /* user and weather widget */
@@ -1294,9 +1305,6 @@ label.user-nav {
   #line-two {
     padding-top: 0;
     margin-bottom: 50px;
-  }
-
-  .heading {
   }
 
   .list-wrapper .expand-item {

--- a/client/src/components/day/Planner.js
+++ b/client/src/components/day/Planner.js
@@ -24,6 +24,8 @@ const Planner = props => {
     if (!user) getUser(dispatch)
   }, [user, dispatch])
 
+  // style={{ overflowY: "auto", overflowX: "visible" }}
+
   return (
     <Fragment>
       <div className="position-div inside-cover">
@@ -38,7 +40,7 @@ const Planner = props => {
               </div>
               <PlannerNavigation {...props} />
             </div>
-            <div className="pattern__wrapper" style={{ overflowY: "auto", overflowX: "visible" }}>
+            <div className="pattern__wrapper">
               <Route path="/planner/day" component={Daily} />
               <Route path="/planner/month" component={Month} />
             </div>

--- a/client/src/components/day/Planner.js
+++ b/client/src/components/day/Planner.js
@@ -24,8 +24,6 @@ const Planner = props => {
     if (!user) getUser(dispatch)
   }, [user, dispatch])
 
-  // style={{ overflowY: "auto", overflowX: "visible" }}
-
   return (
     <Fragment>
       <div className="position-div inside-cover">

--- a/client/src/components/day/content/Content.js
+++ b/client/src/components/day/content/Content.js
@@ -22,8 +22,8 @@ const Content = () => {
         {items.map(({ item, _id, style, moved, notes }) => {
           return <List key={_id} id={_id} item={item} list={list} style={style} moved={moved} notes={notes} />
         })}
-        <Input />
       </ul>
+      <Input />
     </div>
   )
 }

--- a/client/src/components/day/content/Input.js
+++ b/client/src/components/day/content/Input.js
@@ -32,33 +32,31 @@ const Input = ({ content = "", id = "", undoEdit, autoFocus = false }) => {
   }
 
   const submitButtonStyle = {
-    maxHeight: "30px",
-    minHeight: "30px",
-    minWidth: "30px",
-    maxWidth: "30px",
+    // maxHeight: "30px",
+    // minHeight: "30px",
+    // minWidth: "30px",
+    // maxWidth: "30px",
   }
 
   return (
-    <li>
-      <form className="list-item-form" onSubmit={create}>
-        <input
-          name="newItem"
-          className="new-item"
-          type="text"
-          placeholder="Plan your day ..."
-          autoComplete="off"
-          value={inputText}
-          onChange={typing}
-          aria-label="Create list item"
-          autoFocus
-        />
-        <CSSTransition in={!!inputText} classNames="button-appear" timeout={150} unmountOnExit>
-          <Fab type="submit" style={submitButtonStyle}>
-            <AddIcon />
-          </Fab>
-        </CSSTransition>
-      </form>
-    </li>
+    <form className="list-item-form" onSubmit={create}>
+      <input
+        name="newItem"
+        className="new-item"
+        type="text"
+        placeholder="Plan your day ..."
+        autoComplete="off"
+        value={inputText}
+        onChange={typing}
+        aria-label="Create list item"
+        autoFocus={autoFocus}
+      />
+      <CSSTransition in={!!inputText} classNames="button-appear" timeout={150}>
+        <Fab type="submit" style={submitButtonStyle}>
+          <AddIcon />
+        </Fab>
+      </CSSTransition>
+    </form>
   )
 }
 

--- a/client/src/components/day/content/Input.js
+++ b/client/src/components/day/content/Input.js
@@ -38,6 +38,8 @@ const Input = ({ content = "", id = "", undoEdit, autoFocus = false }) => {
     // maxWidth: "30px",
   }
 
+  console.log(!!inputText)
+
   return (
     <form className="list-item-form" onSubmit={create}>
       <input

--- a/client/src/components/day/content/Input.js
+++ b/client/src/components/day/content/Input.js
@@ -4,11 +4,13 @@ import playAudio from "../../../utils/playAudio"
 import { setItem } from "../../../utils/api/item"
 
 import AddIcon from "@material-ui/icons/Add"
+import CheckIcon from "@material-ui/icons/Check"
+import BlockIcon from "@material-ui/icons/Block"
 import Fab from "@material-ui/core/Fab"
 
 import { CSSTransition } from "react-transition-group"
 
-const Input = ({ content = "", id = "", undoEdit, autoFocus = false }) => {
+const Input = ({ content = "", id = "", undoEdit, edit = null, autoFocus = false }) => {
   const {
     state: { list },
     dispatch,
@@ -44,11 +46,27 @@ const Input = ({ content = "", id = "", undoEdit, autoFocus = false }) => {
         aria-label="Create list item"
         autoFocus={autoFocus}
       />
-      <CSSTransition in={!!inputText} classNames="button-appear" timeout={150}>
-        <Fab type="submit">
-          <AddIcon />
-        </Fab>
-      </CSSTransition>
+      {edit ? (
+        <div className="edit-info-button-group">
+          <button className="edit-info-form-action" type="submit" aria-label="Submit list item changes">
+            <CheckIcon />
+          </button>
+          <button
+            className="edit-info-form-action"
+            type="button"
+            onClick={() => undoEdit()}
+            aria-label="Cancel list item changes"
+          >
+            <BlockIcon />
+          </button>
+        </div>
+      ) : (
+        <CSSTransition in={!!inputText} classNames="button-appear" timeout={150}>
+          <Fab type="submit" className="new-item-submit">
+            <AddIcon />
+          </Fab>
+        </CSSTransition>
+      )}
     </form>
   )
 }

--- a/client/src/components/day/content/Input.js
+++ b/client/src/components/day/content/Input.js
@@ -31,15 +31,6 @@ const Input = ({ content = "", id = "", undoEdit, autoFocus = false }) => {
     }
   }
 
-  const submitButtonStyle = {
-    // maxHeight: "30px",
-    // minHeight: "30px",
-    // minWidth: "30px",
-    // maxWidth: "30px",
-  }
-
-  console.log(!!inputText)
-
   return (
     <form className="list-item-form" onSubmit={create}>
       <input
@@ -54,7 +45,7 @@ const Input = ({ content = "", id = "", undoEdit, autoFocus = false }) => {
         autoFocus={autoFocus}
       />
       <CSSTransition in={!!inputText} classNames="button-appear" timeout={150}>
-        <Fab type="submit" style={submitButtonStyle}>
+        <Fab type="submit">
           <AddIcon />
         </Fab>
       </CSSTransition>

--- a/client/src/components/day/content/Input.js
+++ b/client/src/components/day/content/Input.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect } from "react"
+import React, { useState, useContext, useLayoutEffect } from "react"
 import AppContext from "../../../context/application/AppContext"
 import playAudio from "../../../utils/playAudio"
 import { setItem } from "../../../utils/api/item"
@@ -18,7 +18,7 @@ const Input = ({ content = "", id = "", undoEdit, edit = null, autoFocus = false
 
   const [inputText, setInputText] = useState("")
 
-  useEffect(() => setInputText(content), [content])
+  useLayoutEffect(() => setInputText(content), [content])
 
   const typing = e => setInputText(e.target.value)
 

--- a/client/src/components/day/content/List.js
+++ b/client/src/components/day/content/List.js
@@ -65,7 +65,9 @@ const List = ({ list, id, moved, style, item, notes }) => {
   }
 
   return edit ? (
-    <Input content={item} undoEdit={undoEdit} id={id} aria-label="Editing list item" autoFocus />
+    <li className="list-inline-edit">
+      <Input content={item} undoEdit={undoEdit} id={id} aria-label="Editing list item" autoFocus />
+    </li>
   ) : (
     <li onClick={openMenu} className={moved ? "no-bullet-point" : ""}>
       <div className="list-wrapper">

--- a/client/src/components/day/content/List.js
+++ b/client/src/components/day/content/List.js
@@ -28,6 +28,7 @@ const List = ({ list, id, moved, style, item, notes }) => {
   const listItemText = useRef()
 
   const cross = () => {
+    if (!listItemText.current) return
     const strike = listItemText.current.classList
     strike.toggle("strikethrough")
     strike.value && playAudio("cross")
@@ -58,45 +59,50 @@ const List = ({ list, id, moved, style, item, notes }) => {
     setMenu(!menu)
   }
 
-  let flagStyle = {
-    position: "absolute",
-    top: "6px",
-    left: "-26px",
-  }
+  const listItemClassNames = [moved ? "no-bullet-point" : "", edit ? "list-inline-edit" : ""].join(" ")
 
-  return edit ? (
-    <li className="list-inline-edit">
-      <Input content={item} undoEdit={undoEdit} id={id} aria-label="Editing list item" autoFocus />
-    </li>
-  ) : (
-    <li onClick={openMenu} className={moved ? "no-bullet-point" : ""}>
+  return (
+    <li onClick={edit ? null : openMenu} className={listItemClassNames}>
       <div className="list-wrapper">
         {moved && itemStyle ? (
-          <TurnedInIcon style={{ ...flagStyle, opacity: "0.6" }} />
+          <TurnedInIcon className="list-marker complete" />
         ) : (
-          moved && <TurnedInNotIcon style={flagStyle} />
+          moved && <TurnedInNotIcon className="list-marker" />
         )}
 
-        <span ref={listItemText} className={style}>
-          {item}
-        </span>
-        <button aria-label={`expand-item: ${item}`} className="expand-item">
-          {notes?.length ? <NotesIcon /> : <MoreVertIcon />}
-        </button>
-        <CSSTransition in={menu} timeout={300} classNames="revealnotes" unmountOnExit>
-          <Notes
-            notes={notes}
-            openMenu={openMenu}
-            list={list}
+        {edit ? (
+          <Input
+            content={item}
+            edit={edit}
+            undoEdit={undoEdit}
             id={id}
-            carryOver={carryOver}
-            style={itemStyle}
-            cross={cross}
-            deleteItem={deleteItem}
-            setEdit={setEdit}
+            aria-label="Editing list item"
+            autoFocus
           />
-        </CSSTransition>
+        ) : (
+          <>
+            <span ref={listItemText} className={style}>
+              {item}
+            </span>
+            <button aria-label={`expand-item: ${item}`} className="expand-item">
+              {notes?.length ? <NotesIcon /> : <MoreVertIcon />}
+            </button>
+          </>
+        )}
       </div>
+      <CSSTransition in={menu} timeout={300} classNames="revealnotes" unmountOnExit>
+        <Notes
+          notes={notes}
+          openMenu={openMenu}
+          list={list}
+          id={id}
+          carryOver={carryOver}
+          style={itemStyle}
+          cross={cross}
+          deleteItem={deleteItem}
+          setEdit={setEdit}
+        />
+      </CSSTransition>
     </li>
   )
 }

--- a/client/src/components/day/content/Note.js
+++ b/client/src/components/day/content/Note.js
@@ -30,7 +30,6 @@ const Note = ({ note, list, id }) => {
           value={newNoteText}
           onChange={e => setNewNoteText(e.target.value)}
           className="edit-note"
-          autoFocus
           aria-label="List item note"
         />
         <div className="edit-note-button-group">

--- a/client/src/components/day/content/Notes.js
+++ b/client/src/components/day/content/Notes.js
@@ -41,7 +41,6 @@ const Notes = ({ notes, openMenu, list, id, ...rest }) => {
               onChange={e => setNewNote(e.target.value)}
               value={newNote}
               placeholder="Write a note ..."
-              autoFocus
             />
             <Fab type="submit" className="add-note--button" aria-label="add note">
               <AddIcon />
@@ -50,7 +49,7 @@ const Notes = ({ notes, openMenu, list, id, ...rest }) => {
           <ul className="notes-list">
             {notes.length ? (
               notes.map((note, i) => {
-                return <Note key={i} note={note} id={id} list={list} />
+                return <Note key={id} note={note} id={id} list={list} />
               })
             ) : (
               <li></li>

--- a/client/src/components/day/content/Notes.js
+++ b/client/src/components/day/content/Notes.js
@@ -49,7 +49,7 @@ const Notes = ({ notes, openMenu, list, id, ...rest }) => {
           <ul className="notes-list">
             {notes.length ? (
               notes.map(note => {
-                return <Note key={crypto.randomUUID()} note={note} id={id} list={list} />
+                return <Note key={Math.random()} note={note} id={id} list={list} />
               })
             ) : (
               <li></li>

--- a/client/src/components/day/content/Notes.js
+++ b/client/src/components/day/content/Notes.js
@@ -48,8 +48,8 @@ const Notes = ({ notes, openMenu, list, id, ...rest }) => {
           </form>
           <ul className="notes-list">
             {notes.length ? (
-              notes.map((note, i) => {
-                return <Note key={id} note={note} id={id} list={list} />
+              notes.map(note => {
+                return <Note key={crypto.randomUUID()} note={note} id={id} list={list} />
               })
             ) : (
               <li></li>

--- a/client/src/components/day/heading/Datepicker.js
+++ b/client/src/components/day/heading/Datepicker.js
@@ -40,7 +40,7 @@ const Datepicker = () => {
         todayButton={<button>Go To Today</button>}
         customInput={
           <DateLabel className="date-picker" currentValue={getPrintedDate(date)}>
-            {getShortFormDate(date)}
+            <span>{getShortFormDate(date)}</span>
             <TodayOutlinedIcon />
           </DateLabel>
         }

--- a/client/src/components/day/views/Month.js
+++ b/client/src/components/day/views/Month.js
@@ -70,7 +70,7 @@ const Month = () => {
     setLoading(true)
     const selectedSquare = e.currentTarget.getAttribute("data-date")
     const day = splitListName(selectedSquare).day || selectedSquare
-    const dateConstruct = `${current.year} ${current.month + 1} ${day.padStart(2, "0")}`
+    const dateConstruct = `${current.month + 1}/${day.padStart(2, "0")}/${current.year}`
     const listName = getFormattedDate(new Date(dateConstruct))
     const newList = monthlyLists.find(list => list.name === listName)
     if (newList) {

--- a/client/src/hooks/useArrowNavigation.js
+++ b/client/src/hooks/useArrowNavigation.js
@@ -68,7 +68,7 @@ const useArrowNavigation = ({ intitalFocus }) => {
   }
 
   const setInitialChildFocus = e => {
-    if (e.target.className.match(/wrapper/)) {
+    if (e.target?.className?.match(/wrapper/)) {
       setFocusedDate(prev => {
         elementRefs.current[prev - 1].focus()
         return prev

--- a/client/src/styles/date-picker.css
+++ b/client/src/styles/date-picker.css
@@ -32,6 +32,10 @@
   padding: 0;
 }
 
+.date-picker span {
+  line-height: 1;
+}
+
 .date-picker:focus {
   outline: auto;
   outline-color: black;
@@ -261,17 +265,12 @@
     flex-direction: column-reverse;
   }
 
-  .date-label svg {
-    transform: scale(0.8);
-  }
-
   .date-picker {
     font-size: 0.875rem;
     margin-right: 0;
     line-height: 1;
     flex-direction: column-reverse;
     color: var(--faded);
-    height: auto !important;
     width: 100%;
   }
 

--- a/client/src/styles/date-picker.css
+++ b/client/src/styles/date-picker.css
@@ -145,7 +145,6 @@
 .react-datepicker__day--keyboard-selected {
   outline: auto;
   outline-color: var(--brown-color);
-  /* outline-offset: 10px; */
 }
 
 .react-datepicker__day--selected,
@@ -170,7 +169,6 @@
   border: 4px solid #d4caa3;
   outline: auto;
   outline-color: var(--brown-color);
-  /* outline-color: black; */
 }
 
 .react-datepicker__day-name {

--- a/client/src/styles/date-picker.css
+++ b/client/src/styles/date-picker.css
@@ -5,8 +5,7 @@
 }
 
 .date-label:focus-within {
-  outline-offset: 2px;
-  outline: auto;
+  outline: none !important;
 }
 
 .month-label {
@@ -34,7 +33,9 @@
 }
 
 .date-picker:focus {
-  outline: none;
+  outline: auto;
+  outline-color: black;
+  outline-offset: 2px;
 }
 
 .date-label input,
@@ -140,11 +141,12 @@
 .react-datepicker__day--keyboard-selected {
   outline: auto;
   outline-color: var(--brown-color);
+  /* outline-offset: 10px; */
 }
 
 .react-datepicker__day--selected,
 .react-datepicker__month--selected {
-  background-color: var(--brown-color);
+  background-color: var(--brown-color) !important;
   color: #fff7d9;
   border-radius: 6px;
 }
@@ -164,6 +166,7 @@
   border: 4px solid #d4caa3;
   outline: auto;
   outline-color: var(--brown-color);
+  /* outline-color: black; */
 }
 
 .react-datepicker__day-name {
@@ -221,8 +224,10 @@
   background: none;
   border: none;
   cursor: pointer;
+  color: black;
   font-family: var(--serif-font);
-  padding: 0.5rem;
+  font-size: 1.15rem;
+  padding: 0.25rem;
   transition: background-color 75ms ease;
 }
 
@@ -252,6 +257,7 @@
 
 @media (max-width: 500px) {
   .date-label {
+    color: var(--faded) !important;
     flex-direction: column-reverse;
   }
 

--- a/client/src/styles/monthly.css
+++ b/client/src/styles/monthly.css
@@ -34,6 +34,7 @@
   font-family: var(--serif-font);
   font-size: 1.5rem;
   font-weight: 400;
+  color: black;
   position: relative;
   flex-basis: 250px;
 }
@@ -251,8 +252,9 @@
   }
 
   .month__cell--preview {
-    grid-row: 8;
+    grid-row: 8 / span 1;
     grid-column: 1 / span 7;
     aspect-ratio: unset;
+    margin-inline: 0;
   }
 }

--- a/client/src/styles/page-nav.css
+++ b/client/src/styles/page-nav.css
@@ -37,6 +37,7 @@
   cursor: pointer;
   padding: 0.125rem 0.25rem;
   display: flex;
+  justify-content: center;
 }
 
 .page-nav--button:hover {


### PR DESCRIPTION
Layout
- Mobile full screen height now fixes to `svh`
- List item menu allows inline edit while open
- List item edit has wysiwyg style and updated action buttons
- Focus outline on list items with active edit
- Button click zones improved
- profile page inputs fixed to paper line height
- Extend narrow screen layout to full height

Bug fixes
- Safari monthly view calendar date click
- Floating bullet point on list item input in iOS
- Blue outline around opened date picker in iOS
- Strikethrough while editing list item crash
- Item notes unique key issue